### PR TITLE
healthcheckエンドポイントを作成した

### DIFF
--- a/app/presentation/router.go
+++ b/app/presentation/router.go
@@ -46,7 +46,8 @@ func Router() *gin.Engine {
 		handler.TaskMoveToChild(c)
 	})
 
-	r.GET("/healthcheck", func(c *gin.Context) {
+	// `/` endpoint is used to healthcheck.
+	r.GET("/", func(c *gin.Context) {
 		c.String(http.StatusOK, "ok")
 	})
 

--- a/app/presentation/router.go
+++ b/app/presentation/router.go
@@ -1,6 +1,8 @@
 package presentation
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/whalepod/milelane/app/presentation/handler"
@@ -42,6 +44,10 @@ func Router() *gin.Engine {
 
 	r.POST("/tasks/:taskID/move-to-child/:parentTaskID", func(c *gin.Context) {
 		handler.TaskMoveToChild(c)
+	})
+
+	r.GET("/healthcheck", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
 	})
 
 	return r

--- a/app/presentation/router_test.go
+++ b/app/presentation/router_test.go
@@ -67,7 +67,7 @@ func TestRouter(t *testing.T) {
 		t.Fatal("Returned wrong http status.")
 	}
 
-	res = performRequest(router, "GET", "/healthcheck", nil)
+	res = performRequest(router, "GET", "/", nil)
 	if http.StatusOK != res.Code {
 		t.Fatal("Returned wrong http status.")
 	}

--- a/app/presentation/router_test.go
+++ b/app/presentation/router_test.go
@@ -67,5 +67,10 @@ func TestRouter(t *testing.T) {
 		t.Fatal("Returned wrong http status.")
 	}
 
+	res = performRequest(router, "GET", "/healthcheck", nil)
+	if http.StatusOK != res.Code {
+		t.Fatal("Returned wrong http status.")
+	}
+
 	t.Log("Success.")
 }


### PR DESCRIPTION
## Issue

close #32 

## 背景

ingressがサービスの死活監視をする際にヘルスチェックする必要があるのだが、この対象になるエンドポイントがなかったので作った。

## 追記

外部サービス(GKE)の都合だが、ヘルスチェックエンドポイントは `/` でないとヘルスチェックに通らないため、 `/` を対象のエンドポイントにした。

https://github.com/kubernetes/ingress-gce/issues/39
https://github.com/kubernetes/ingress-gce/issues/42