### PR TITLE
スキーマでデータベースを指定するようにした

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,5 +1,3 @@
-USE `milelane`;
-
 CREATE TABLE IF NOT EXISTS `devices` (
   `uuid` VARCHAR(36) NOT NULL PRIMARY KEY,
   `device_token` VARCHAR(255) NOT NULL,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,3 +1,5 @@
+USE `milelane`;
+
 CREATE TABLE IF NOT EXISTS `devices` (
   `uuid` VARCHAR(36) NOT NULL PRIMARY KEY,
   `device_token` VARCHAR(255) NOT NULL,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
             - 3306:3306
         environment:
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+            - MYSQL_DATABASE=milelane
+            - MYSQL_USER=root
         volumes:
             - mysql-data:/var/lib/mysql
             - ./db:/docker-entrypoint-initdb.d


### PR DESCRIPTION
## 内容
fix #54 

## 実装内容
- `docker-compose.yaml` に mysql が用意する環境変数を指定し、最初に使用するデータベースを設定

### 実装変更理由
```
USE `milelane`;
```

上記の実装だと、`CircleCI`で指定するデータベースが異なるため、テストがこけてしまう。
かといってデータベース名を統一するのもテストを行うにあたって適切ではないと考え、この実装にした。
